### PR TITLE
Make more specific chekc for the translation directive

### DIFF
--- a/src/create-report/vue-files.ts
+++ b/src/create-report/vue-files.ts
@@ -78,7 +78,7 @@ function extractComponentMatches (file: SimpleFile): I18NItemWithBounding[] {
 }
 
 function extractDirectiveMatches (file: SimpleFile): I18NItemWithBounding[] {
-  const directiveRegExp = /v-t(?:.*)="'((?:[^\\]|\\.)*?)'"/g;
+  const directiveRegExp = /v-t(?:\.preserve)?="'((?:[^\\]|\\.)*?)'"/g;
   return [ ...getMatches(file, directiveRegExp) ];
 }
 

--- a/tests/fixtures/vue-files/edge-cases.js
+++ b/tests/fixtures/vue-files/edge-cases.js
@@ -25,3 +25,4 @@ _t("FALSE POSITIVE 4");
 w0t("FALSE POSITIVE 5");
 ಠ_ಠt("FALSE POSITIVE 6");
 t(dynamicKey)
+<p v-text="'FALSE POSITIVE 7'"></p>


### PR DESCRIPTION
With the wildcard match for `v-t` directive it would match any existing or
custome directives for vue, e.g. `v-text` which is not desired, since it will
often result in a false positive match