### PR TITLE
fix: handling glob paths incorrectly on Windows

### DIFF
--- a/src/create-report/language-files.ts
+++ b/src/create-report/language-files.ts
@@ -7,11 +7,14 @@ import isValidGlob from 'is-valid-glob';
 import { SimpleFile, I18NLanguage, I18NItem } from '../types';
 
 export function readLanguageFiles (src: string): SimpleFile[] {
-  if (!isValidGlob(src)) {
+  // Replace backslash path segments to make the path work with the glob package.
+  // https://github.com/Spittal/vue-i18n-extract/issues/159
+  const normalizedSrc = src.replace(/\\/g, '/');
+  if (!isValidGlob(normalizedSrc)) {
     throw new Error(`languageFiles isn't a valid glob pattern.`);
   }
 
-  const targetFiles = glob.sync(src);
+  const targetFiles = glob.sync(normalizedSrc);
 
   if (targetFiles.length === 0) {
     throw new Error('languageFiles glob has no files.');

--- a/src/create-report/vue-files.ts
+++ b/src/create-report/vue-files.ts
@@ -4,11 +4,14 @@ import glob from 'glob';
 import fs from 'fs';
 
 export function readVueFiles (src: string): SimpleFile[] {
-  if (!isValidGlob(src)) {
+  // Replace backslash path segments to make the path work with the glob package.
+  // https://github.com/Spittal/vue-i18n-extract/issues/159
+  const normalizedSrc = src.replace(/\\/g, '/');
+  if (!isValidGlob(normalizedSrc)) {
     throw new Error(`vueFiles isn't a valid glob pattern.`);
   }
 
-  const targetFiles = glob.sync(src);
+  const targetFiles = glob.sync(normalizedSrc);
 
   if (targetFiles.length === 0) {
     throw new Error('vueFiles glob has no files.');

--- a/tests/unit/create-report/language-files.spec.ts
+++ b/tests/unit/create-report/language-files.spec.ts
@@ -5,9 +5,14 @@ import { readLanguageFiles, writeMissingToLanguageFiles, removeUnusedFromLanguag
 import { expectedFromParsedLanguageFiles, expectedI18NReport } from '../../fixtures/expected-values';
 import { languageFiles } from '../../fixtures/resolved-sources';
 
+const languageFilesWithBackslashes = languageFiles.replace(/\//g, '\\');
+
 describe('file: create-report/language-files', () => {
   describe('function: parselanguageFiles', () => {
-    it('Parse the file glob into an I18NLanguage object', () => {
+    it.each([
+      languageFiles,
+      languageFilesWithBackslashes
+    ])('Parse the file glob into an I18NLanguage object', (languageFiles) => {
       const I18NLanguage = parselanguageFiles(languageFiles);
       expect(I18NLanguage).toEqual(expectedFromParsedLanguageFiles);
     });
@@ -48,4 +53,3 @@ describe('file: create-report/language-files', () => {
     });
   });
 })
-

--- a/tests/unit/create-report/vue-files.spec.ts
+++ b/tests/unit/create-report/vue-files.spec.ts
@@ -3,10 +3,15 @@ import { expectedFromParsedVueFiles } from '../../fixtures/expected-values';
 import { vueFiles } from '../../fixtures/resolved-sources';
 import path from 'path';
 
+const vueFilesWithBackslashes = vueFiles.replace(/\//g, '\\');
+
 describe('file: create-report/vue-files', () => {
   describe('function: parseVueFiles', () => {
-    it('Parse the file glob into I18n items', () => {
-      const I18NItems = parseVueFiles(vueFiles);
+    it.each([
+      vueFiles,
+      vueFilesWithBackslashes
+    ])('Parse the file glob into I18n items', (files) => {
+      const I18NItems = parseVueFiles(files);
       expect(I18NItems).toEqual(expectedFromParsedVueFiles);
     });
 


### PR DESCRIPTION
Fixes an issue with glob paths being handled incorrectly on Windows caused by a breaking change in the glob package which no longer allows backslashes as path separators.

Intends to fix #159.

---

I don’t use a Windows machine myself, so I’d appreciate someone using testing these changes.

Also, the approach for testing this change is rather naive as I’m merely simulating a Windows-style path by replacing the forward slashes in the paths used in the respective tests which is effectively the inverse of the implemented fix and so it doesn’t test a real scenario. I’m happy to hear about any suggestions improving this.

Furthermore, do you want me to include rebuilt distribution files in the PR branch or do you prefer to build separately before publishing a new version?