### PR TITLE
fix: not reading exclude option from config file

### DIFF
--- a/dist/config-file/vue-i18n-extract.config.d.ts
+++ b/dist/config-file/vue-i18n-extract.config.d.ts
@@ -1,7 +1,7 @@
 declare const _default: {
     vueFiles: string;
     languageFiles: string;
-    excludedKeys: never[];
+    exclude: never[];
     output: boolean;
     add: boolean;
     remove: boolean;

--- a/src/config-file/index.ts
+++ b/src/config-file/index.ts
@@ -12,22 +12,25 @@ export function initCommand(): void {
 
 export function resolveConfig (): Record<string, string>  {
   const argvOptions = cac().parse(process.argv, { run: false }).options;
-  const excluded = argvOptions.exclude;
 
-  argvOptions.exclude = !Array.isArray(excluded) ? [excluded] : excluded
+  let options;
 
   try {
     const pathToConfigFile = path.resolve(process.cwd(), './vue-i18n-extract.config.js');
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const configFile = require(pathToConfigFile);
+    const configOptions = require(pathToConfigFile);
 
     console.info(`\nUsing config file found at ${pathToConfigFile}`);
 
-    return {
-      ...configFile,
+    options = {
+      ...configOptions,
       ...argvOptions
     };
   } catch {
-    return argvOptions;
+    options = argvOptions;
   }
+
+  options.exclude = Array.isArray(options.exclude) ? options.exclude : [options.exclude];
+
+  return options;
 }

--- a/src/config-file/vue-i18n-extract.config.ts
+++ b/src/config-file/vue-i18n-extract.config.ts
@@ -2,7 +2,7 @@ export default {
   // Options documented in vue-i18n-extract readme.
   vueFiles: './src/**/*.?(js|vue)',
   languageFiles: './lang/**/*.?(json|yaml|yml|js)',
-  excludedKeys: [],
+  exclude: [],
   output: false,
   add: false,
   remove: false,

--- a/tests/unit/config-file/index.spec.ts
+++ b/tests/unit/config-file/index.spec.ts
@@ -1,14 +1,37 @@
-import { initCommand, resolveConfig } from '@/config-file';
+import { initCommand, resolveConfig } from '@/config-file';
 import defaultConfig from '@/config-file/vue-i18n-extract.config';
 import rimraf from 'rimraf';
 
 describe('file: config-file/index', () => {
-  it('Init and Read the config file.', (done) => {
+  it('Init default config and read it.', (done) => {
     initCommand();
 
     const config = resolveConfig();
 
     expect(config).toEqual(expect.objectContaining({
+      exclude: defaultConfig.exclude,
+      vueFiles: defaultConfig.vueFiles,
+      languageFiles: defaultConfig.languageFiles,
+    }));
+
+    rimraf('./vue-i18n-extract.config.js', () => {
+      done();
+    });
+  });
+
+  it('Read non-default config.', (done) => {
+    jest.doMock('@/config-file/vue-i18n-extract.config', () => ({
+      vueFiles: './src/**/*.?(js|vue)',
+      languageFiles: './lang/**/*.?(json|yaml|yml|js)',
+      exclude: ['test', 'hello']
+    }));
+
+    initCommand();
+
+    const config = resolveConfig();
+
+    expect(config).toEqual(expect.objectContaining({
+      exclude: defaultConfig.exclude,
       vueFiles: defaultConfig.vueFiles,
       languageFiles: defaultConfig.languageFiles,
     }));


### PR DESCRIPTION
Renames the `excludedKeys` option used in the default configuration file created via `vue-i18n-extract init` to `exclude` so that it matches the `exclude` CLI argument.

Fixes an issue where setting the `exclude` option in the config file wouldn’t work.

Intends to fix #164.