### PR TITLE
fix: false positive v-t directive matches

### DIFF
--- a/src/create-report/vue-files.ts
+++ b/src/create-report/vue-files.ts
@@ -78,7 +78,7 @@ function extractComponentMatches (file: SimpleFile): I18NItemWithBounding[] {
 }
 
 function extractDirectiveMatches (file: SimpleFile): I18NItemWithBounding[] {
-  const directiveRegExp = /v-t(?:.*)="'((?:[^\\]|\\.)*?)'"/g;
+  const directiveRegExp = /\bv-t(?:\.[\w-]+)?="'((?:[^\\]|\\.)*?)'"/g;
   return [ ...getMatches(file, directiveRegExp) ];
 }
 

--- a/tests/fixtures/vue-files/Basic.vue
+++ b/tests/fixtures/vue-files/Basic.vue
@@ -17,5 +17,8 @@
     <p v-t="'header.title'"></p>
     <p v-t.preserve="'header.title'"></p>
     <p>{{ .t('header.title') }}</p>
+    <p v-test="'false.positive'"></p>
+    <p v-test.preserve="'false.positive'"></p>
+    <p testv-t="'false.positive'"></p>
   </div>
 </template>


### PR DESCRIPTION
Fixes an issue with extracting translation keys from Vue directives that aren’t `v-t` (e.g. `v-test`, `testv-t`).

Intends to fix #162.