### PR TITLE
refactor: only package necessary files

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
   "main": "dist/vue-i18n-extract.umd.js",
   "module": "dist/vue-i18n-extract.modern.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "bin",
+    "dist"
+  ],
   "repository": "https://github.com/Spittal/vue-i18n-extract",
   "homepage": "https://github.com/Spittal/vue-i18n-extract",
   "bugs": "https://github.com/Spittal/vue-i18n-extract/issues",


### PR DESCRIPTION
Adds the `files` property to the package.json file including the paths `bin` and `dist` which contain the essential distribution files of the package. Previously, the entire source code was packaged with the files uploaded to npm (for comparison, run `npm pack` with and without this change). This unnecessarily bloats a consuming project’s dependency storage (e.g. `node_modules`).

---

**Caution**: This could be considered a breaking change. While unlikely, it could be that consumers of this package make use of the files as they’re currently being distributed. This is quite unlikely as the source code is written in TypeScript which prevents people from directly importing and using the source code without also compiling the files to JavaScript. Nevertheless, there is always a risk associated to a change like this. Personally, I would probably *not* consider this a breaking change as all functionality can be accessed using files provided in the `dist` and `bin` directories.