### PR TITLE
support '--detect' CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,18 @@ You can generate a default configuration file using `npx vue-i18n-extract init` 
   * Configuration option: `exclude: ['translation_key_1', 'translation_key_2']`
   * CLI argument: `--exclude translation_key_1 --exclude translation_key_2`
 
+### `detect`
+
+* Name: `detect`
+* CLI argument: `--detect`
+* Required: No
+* Default: `['missing', 'unused', 'dynamic']`
+* Type: `string` or array of `string`s
+* Description: Defines what do detect (and include) in the report.
+* Examples:
+  * Configuration option: `detect: ['missing', 'unused']`
+  * CLI argument: `--detect missing --detect unused`
+
 ### `noEmptyTranslation`
 
 * Name: `noEmptyTranslation`

--- a/bin/vue-i18n-extract.js
+++ b/bin/vue-i18n-extract.js
@@ -43,6 +43,10 @@ cli
     '--noEmptyTranslation',
     'Use if you want to generate a default translated string by using the key itself'
    )
+   .option(
+    '--detect <detectionType>',
+    '[string] The type of issues you want to detect (ex. --detect missing) ',
+  )
   .action((options) => {
     createI18NReport(resolveConfig(options));
   });

--- a/src/create-report/report.ts
+++ b/src/create-report/report.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { I18NItem, I18NItemWithBounding, I18NLanguage, I18NReport } from '../types';
+import { DetectionType, I18NItem, I18NItemWithBounding, I18NLanguage, I18NReport } from '../types';
 
 function stripBounding (item: I18NItemWithBounding): I18NItem {
   return {
@@ -14,28 +14,36 @@ function mightBeDynamic (item: I18NItemWithBounding): boolean {
 }
 
 // Looping through the arays multiple times might not be the most effecient, but it's the easiest to read and debug. Which at this scale is an accepted trade-off.
-export function extractI18NReport (vueItems: I18NItemWithBounding[], languageFiles: I18NLanguage): I18NReport {
+export function extractI18NReport (vueItems: I18NItemWithBounding[], languageFiles: I18NLanguage, detect: DetectionType[]): I18NReport {
   const missingKeys: I18NItem[] = [];
   const unusedKeys: I18NItem[] = [];
+  const maybeDynamicKeys: I18NItem[] = [];
 
-  const maybeDynamicKeys: I18NItem[] = vueItems
+  if (detect.includes(DetectionType.Dynamic)) {
+   maybeDynamicKeys. push( ...vueItems
     .filter(vueItem => mightBeDynamic(vueItem))
-    .map(vueItem => stripBounding(vueItem));
+    .map(vueItem => stripBounding(vueItem)));
+   }
 
   Object.keys(languageFiles).forEach(language => {
     const languageItems = languageFiles[language];
 
+    if (detect.includes(DetectionType.Missing)) {
     const missingKeysInLanguage = vueItems
       .filter(vueItem => !mightBeDynamic(vueItem))
       .filter(vueItem => !languageItems.some(languageItem => vueItem.path === languageItem.path))
       .map(vueItem => ({ ...stripBounding(vueItem), language }));
 
+    missingKeys.push(...missingKeysInLanguage);
+    }
+
+    if (detect.includes(DetectionType.Unused)) {
     const unusedKeysInLanguage = languageItems
       .filter(languageItem => !vueItems.some(vueItem => languageItem.path === vueItem.path || languageItem.path.startsWith(vueItem.path + '.')))
       .map(languageItem => ({ ...languageItem, language }));
 
-    missingKeys.push(...missingKeysInLanguage);
     unusedKeys.push(...unusedKeysInLanguage);
+    }
   });
 
   return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,13 @@ export type ReportOptions = {
   ci?: boolean;
   separator?: string;
   noEmptyTranslation?: string;
+  detect?: DetectionType[];
+}
+
+export enum DetectionType {
+  Missing = "missing",
+  Unused = "unused",
+  Dynamic = "dynamic"
 }
 
 export type SimpleFile = {

--- a/tests/unit/cli.spec.ts
+++ b/tests/unit/cli.spec.ts
@@ -32,6 +32,20 @@ describe('vue-i18n-extract CLI', () => {
     expect(result.stderr).toContain(`Required configuration vueFiles is missing.`);
   });
 
+  it('Fail with invalid detect, and give a hint.', async () => {
+    const result = await runCLI([
+      '--vueFiles',
+      `'./tests/fixtures/vue-files/**/*.?(vue|js)'`,
+      '--languageFiles',
+      `'./tests/fixtures/lang/**/*.?(json|yml|yaml)'`,
+      '--detect',
+      `'invalidDetect'`,
+    ]);
+
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain(`Invalid 'detect' value(s): invalidDetect`);
+  });
+
   it('Show help', async () => {
     const result = await runCLI(['--help']);
     expect(result.code).toBe(0);
@@ -55,6 +69,16 @@ describe('vue-i18n-extract CLI', () => {
         `'./tests/fixtures/vue-files/**/*.?(vue|js)'`,
         '--languageFiles',
         `'./tests/fixtures/lang/**/*.?(json|yml|yaml)'`,
+      ])).code).toBe(0);
+
+      expect((await runCLI([
+        '--vueFiles',
+        `'./tests/fixtures/vue-files/**/*.?(vue|js)'`,
+        '--languageFiles',
+        `'./tests/fixtures/lang/**/*.?(json|yml|yaml)'`,
+        '--detect',
+        `'missing'
+        `,
       ])).code).toBe(0);
 
       expect((await runCLI([

--- a/tests/unit/create-report/index.spec.ts
+++ b/tests/unit/create-report/index.spec.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { createI18NReport } from '@/create-report';
-import { ReportOptions } from '@/types';
+import { DetectionType, ReportOptions } from '@/types';
 import { expectedI18NReport } from '../../fixtures/expected-values';
 import { vueFiles, languageFiles } from '../../fixtures/resolved-sources';
 import * as report from '@/create-report/report';
@@ -121,5 +121,14 @@ describe('file: create-report/index', () => {
       Dot,
     );
     expect(consoleInfoSpy).toHaveBeenLastCalledWith('\nThe unused keys have been removed from your language files.');
+  });
+
+  it('Only detect missing', async () => {
+    const report = await createI18NReport({...options, detect: [DetectionType.Missing]});
+    const expectedI18NReportOnlyDetectingMissing = {...expectedI18NReport, unusedKeys: [], maybeDynamicKeys: []};
+    
+    expect(report).toEqual(
+      expectedI18NReportOnlyDetectingMissing
+    );
   });
 });

--- a/tests/unit/create-report/report.spec.ts
+++ b/tests/unit/create-report/report.spec.ts
@@ -4,7 +4,7 @@ import { parseVueFiles } from '@/create-report/vue-files';
 import { parselanguageFiles } from '@/create-report/language-files';
 import { expectedI18NReport } from '../../fixtures/expected-values';
 import { vueFiles, languageFiles } from '../../fixtures/resolved-sources';
-import { I18NReport, I18NLanguage, I18NItemWithBounding } from '@/types';
+import { I18NReport, I18NLanguage, I18NItemWithBounding, DetectionType } from '@/types';
 
 describe('file: create-report/report', () => {
   let parsedVueFiles: I18NItemWithBounding[];
@@ -14,7 +14,7 @@ describe('file: create-report/report', () => {
   beforeAll(() => {
     parsedVueFiles = parseVueFiles(vueFiles);
     parsedLanguageFiles = parselanguageFiles(languageFiles);
-    report = extractI18NReport(parsedVueFiles, parsedLanguageFiles);
+    report = extractI18NReport(parsedVueFiles, parsedLanguageFiles, [DetectionType.Missing, DetectionType.Unused, DetectionType.Dynamic]);
   });
 
   describe('function: extractI18NReport', () => {


### PR DESCRIPTION
Adds a new option to decide what kind of issues we want to detect, the default behaviour stays the same when `--detect` is not specified